### PR TITLE
Don't use chrome sandbox

### DIFF
--- a/testsuite/oauth/authorize/allscripts.py
+++ b/testsuite/oauth/authorize/allscripts.py
@@ -4,6 +4,7 @@ import time
 
 from pyvirtualdisplay import Display
 from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
 
 from . import base
 
@@ -29,7 +30,10 @@ class AllscriptsAuthorizer(base.AbstractAuthorizer):
         self.display = Display(visible=0, size=(800, 600))
         self.display.start()
 
-        return webdriver.Chrome()
+        options = Options()
+        options.add_argument("--no-sandbox")
+
+        return webdriver.Chrome(chrome_options=options)
 
     def _vendor_step(self):
         """ Vendor Step skeleton method.


### PR DESCRIPTION
Something about the demo-test docker image refused to start chromium. That's what was taking > 1 min. We don't actually have to mess with nginx or uwsgi configs to fix the 504 timeout.

Built my local docker and the demo-test docker image from scratch, the local one worked. The remote one couldn't start because it couldn't start the sandbox. If you tell it not to, it starts just fine. This works locally as well. This isn't how your'e supposed to run chrome, but since we're just spinning up a single tab and then closing it again, it's not a huge deal.