### PR TITLE
Import CVX codes and fix bug is "is bound to" step.

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -23,3 +23,7 @@
 ## CPT
 
 * Source: [https://www.nlm.nih.gov/research/umls/licensedcontent/umlsknowledgesources.html]
+
+## CVX
+
+* Source: [http://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx] (NB: "notes" column for code 132 is a multiline field and needs to be quoted)

--- a/data/build_bf.py
+++ b/data/build_bf.py
@@ -17,6 +17,7 @@ SNOMED = 'http://snomed.info/sct'
 RXNORM = 'http://www.nlm.nih.gov/research/umls/rxnorm'
 ICD10 = 'http://hl7.org/fhir/sid/icd-10'
 CPT = 'http://www.ama-assn.org/go/cpt'
+CVX = 'http://hl7.org/fhir/sid/cvx'
 
 # SOURCES
 LOINC_PATH = './loinc/loinc.csv'
@@ -25,6 +26,7 @@ RXNORM_PATH = './rxnorm/rrf/RXNCONSO.RRF'
 RXNORM_DEPRECATED_PATH = './rxnorm/rrf/RXNCUI.RRF'
 ICD10_PATH = './icd10/icd10cm_tabular_2017.xml'
 CPT_PATH = './cpt/MRCONSO.RRF'
+CVX_PATH = './cvx/cvx.txt'
 
 
 def import_loinc(bf):
@@ -192,6 +194,23 @@ def import_argo(bf):
         json.dump(argo_systems, handle)
 
 
+def import_cvx(bf):
+    fieldnames = [
+        'cvx code',
+        'short description',
+        'full vaccines name',
+        'notes',
+        'vaccine status',
+        'nonvaccine',
+        'last updated date',
+    ]
+    with open(CVX_PATH, encoding='utf-16') as handle:
+        reader = csv.DictReader(handle, delimiter='|', fieldnames=fieldnames)
+
+        for row in reader:
+            bf.add(CVX + '|' + row['cvx code'].strip())
+
+
 try:
     # If the bloom filter already exists, we're probably just appending to it
     with open('./codes.bf', 'rb') as handle:
@@ -210,6 +229,7 @@ import_cpt(bf)
 import_fhir(bf)
 import_daf(bf)
 import_argo(bf)
+import_cvx(bf)
 
 if __name__ == '__main__':
     with open('./codes.bf', 'wb') as handle:

--- a/features/00-lab-results.feature
+++ b/features/00-lab-results.feature
@@ -45,7 +45,7 @@ Feature: Lab results
         And there exists a fixed Observation.category.coding.code=laboratory
         Then there exists one code in Observation.code
         And there exists a fixed Observation.code.coding.system=http://loinc.org
-        And Observation.code.coding.code is bound to http://loinc.org
+        And Observation.code is bound to http://loinc.org
         # Then Either one Observation.value[x] or one code in Observation.DataAbsentReason
         Then there exists one reference to a Patient in Observation.subject
         Then there exists one date and time in Observation.effectiveDateTime or Observation.effectivePeriod

--- a/features/00-smoking.feature
+++ b/features/00-smoking.feature
@@ -41,4 +41,4 @@ Feature: Smoking status
         Then there exists one reference to a Patient in Observation.subject
         Then there exists one instant in Observation.issued
         Then there exists one value in Observation.valueCodeableConcept
-        Then Observation.valueCodeableConcept.coding.code is bound to http://hl7.org/fhir/ValueSet/daf-observation-ccdasmokingstatus
+        Then Observation.valueCodeableConcept is bound to http://hl7.org/fhir/ValueSet/daf-observation-ccdasmokingstatus

--- a/features/00-vital-signs.feature
+++ b/features/00-vital-signs.feature
@@ -39,7 +39,7 @@ Feature: Vital signs
         And there exists a fixed Observation.category.coding.code=vital-signs
         Then there exists one code in Observation.code
         And there exists a fixed Observation.code.coding.system=http://loinc.org
-        And Observation.code.coding.code is bound to http://argonautwiki.hl7.org/ValueSet/argo-vital-signs
+        And Observation.code is bound to http://argonautwiki.hl7.org/ValueSet/argo-vital-signs
         # Then Either one Observation.valueQuantity or, if there is no value, one code in Observation.DataAbsentReason
         # Then when using a panel code...
         Then there exists one patient in Observation.subject

--- a/features/steps/argonaut.py
+++ b/features/steps/argonaut.py
@@ -1,11 +1,16 @@
 # pylint: disable=missing-docstring,function-redefined
 from functools import reduce
+import json
 
 from behave import then
 
 from features.steps import utils
 from testsuite import systems
 
+ERROR_CODING_MISSING = '''
+{field_name} is missing field "coding".
+{json}
+'''
 ERROR_INVALID_BINDING = '{code} is not found in {system}.'
 ERROR_REFERENCE_MATCH = '{reference} is not a {resource_type}.'
 ERROR_REQUIRED = '{name} not found.'
@@ -123,6 +128,13 @@ def step_impl(context, field_name, value_set_url_one, value_set_url_two):
         found = traverse(res, path)
         if isinstance(found, str):
             found = [found]
+        elif isinstance(found, dict):
+            assert 'coding' in found, \
+                utils.bad_response_assert(context.response,
+                                          ERROR_CODING_MISSING,
+                                          field_name=field_name,
+                                          json=json.dumps(found, indent=2))
+            found = [coding.get('code') for coding in found.get('coding')]
 
         for code in found:
             try:
@@ -148,6 +160,13 @@ def step_impl(context, field_name, value_set_url):
         found = traverse(res, path)
         if isinstance(found, str):
             found = [found]
+        elif isinstance(found, dict):
+            assert 'coding' in found, \
+                utils.bad_response_assert(context.response,
+                                          ERROR_CODING_MISSING,
+                                          field_name=field_name,
+                                          json=json.dumps(found, indent=2))
+            found = [coding.get('code') for coding in found.get('coding')]
 
         for code in found:
             try:

--- a/testsuite/systems.py
+++ b/testsuite/systems.py
@@ -10,8 +10,9 @@ SNOMED = 'http://snomed.info/sct'
 RXNORM = 'http://www.nlm.nih.gov/research/umls/rxnorm'
 ICD10 = 'http://hl7.org/fhir/sid/icd-10'
 CPT = 'http://www.ama-assn.org/go/cpt'
+CVX = 'http://hl7.org/fhir/sid/cvx'
 
-RECOGNIZED = [LOINC, SNOMED, RXNORM, ICD10, CPT]
+RECOGNIZED = [LOINC, SNOMED, RXNORM, ICD10, CPT, CVX]
 
 # Enumerating all the FHIR systems here would be a waste of time,
 # so load them from the constructed json file.


### PR DESCRIPTION
Argonaut "is bound to" steps were failing to recognize Codeable Concepts and not looking for codings inside them. Instead we were binding `code.coding.code` which didn't really provide helpful error messages.

```
And Immunization.vaccineCode.coding.code is bound to http://hl7.org/fhir/sid/cvx
    ...
    TypeError: 'NoneType' object is not iterable
```

vs.

```
And Immunization.vaccineCode is bound to http://hl7.org/fhir/sid/cvx
    Assertion Failed: Immunization.vaccineCode is missing field "coding".
    {
      "text": "mixed respiratory vaccine"
    }
```

This affected:
* Immunizations
* Lab results
* Problems
* Procedures
* Smoking status
* Vital signs

Fixes https://github.com/sync-for-science/tracking/issues/69.