### PR TITLE
Test "do not authorize" flow

### DIFF
--- a/config/cerner.yml
+++ b/config/cerner.yml
@@ -13,7 +13,11 @@ auth:
       send_keys: "ARGONAUT"
     - element: "#j_password"
       send_keys: "sprinttest"
+  authorize_steps:
     - element: "#loginButton"
+      click: True
+  cancel_steps:
+    - element: "#cancelButton"
       click: True
   extra_launch_params:
     launch: 8de5dad5-4e22-4b06-bde5-60f6a5781fd0

--- a/config/eclinicalworks.yml
+++ b/config/eclinicalworks.yml
@@ -20,3 +20,6 @@ auth:
   authorize_steps:
     - element: '#grant_clicked'
       click: True
+  cancel_steps:
+    - element: '#cancel_clicked'
+      click: True

--- a/config/epic.yml
+++ b/config/epic.yml
@@ -15,5 +15,9 @@ auth:
       send_keys: "ARGONAUT"
     - element: "#txtPassword"
       send_keys: "ARGONAUT"
+  authorize_steps:
     - element: "#cmdLogin"
+      click: True
+  cancel_steps:
+    - element: "#cmdCancel"
       click: True

--- a/config/smart.yml
+++ b/config/smart.yml
@@ -25,4 +25,6 @@ auth:
       click: True
     - element: '.modal form button'
       click: True
-
+  cancel_steps:
+    - element: '#consent-carousel .btn-default'
+      click: True

--- a/features/20-ehr-evaluates-authorization.feature
+++ b/features/20-ehr-evaluates-authorization.feature
@@ -24,3 +24,9 @@ Feature: EHR evaluates authorization request
             | key | value |
             | state | ‘’“”✓☃èÉéÊ¿¡Ææ汉语 |
         Then the authorization response redirect should validate
+
+    Scenario: Authorization request is aborted
+        Given OAuth is enabled
+        And I am not logged in
+        When I abort an authorization request
+        Then the authorization error response error code should be "access_denied"

--- a/testsuite/oauth/authorize.py
+++ b/testsuite/oauth/authorize.py
@@ -212,7 +212,7 @@ class Authorizer(object):
 
         if 'error' in query:
             raise ReturnedErrorException(query['error'],
-                                         query.get('error_descriptoin'),
+                                         query.get('error_description'),
                                          self.runner.browser)
 
         return query


### PR DESCRIPTION
This is incomplete, as Allscripts appears to be down at the moment, so I can't update their config.

I wanted to get your thoughts on my implementation though. When the "I abort an authorization request" step is reached, it replaces the "authorize_steps" part of the config with "cancel_steps". This worked well for SMART and eClinicalWorks, who already had a distinct "authorize" flow, but some of the vendors treat logging in as authorizing, so I had to break the "clicking the login button" step into an "authorize" flow. I don't think that's quite correct, but it doesn't cause any problems. Thoughts?