### PR TITLE
Click the drchrono authorize button if presented

### DIFF
--- a/config/drchrono.yml
+++ b/config/drchrono.yml
@@ -16,3 +16,7 @@ auth:
       send_keys: "X6mx5AYmT7rUdVv44sZP"
     - element: "button[type='submit']"
       click: True
+  authorize_steps:
+    - element: "#authorizationForm [value='Authorize']"
+      click: True
+      optional: True


### PR DESCRIPTION
Drchrono seems to "remember" authorizations, so the authorize screen is not always presented. Otherwise, the "cancel_steps" could also be implemented.