### PR TITLE
Insert dot into ICD9 codes for validation

### DIFF
--- a/data/build_bf.py
+++ b/data/build_bf.py
@@ -100,7 +100,7 @@ def import_icd9(bf):
     with open(ICD9_PATH, encoding='cp1252') as handle:
         for line in handle.readlines():
             code, desc = re.split(r'\s+', line, maxsplit=1)
-            bf.add(ICD9 + '|' + code)
+
             # Splice a "." into the code at position 3
             dot_code = '.'.join((code[:3], code[3:]))
             bf.add(ICD9 + '|' + dot_code)

--- a/data/build_bf.py
+++ b/data/build_bf.py
@@ -101,6 +101,9 @@ def import_icd9(bf):
         for line in handle.readlines():
             code, desc = re.split(r'\s+', line, maxsplit=1)
             bf.add(ICD9 + '|' + code)
+            # Splice a "." into the code at position 3
+            dot_code = '.'.join((code[:3], code[3:]))
+            bf.add(ICD9 + '|' + dot_code)
 
 
 def import_cpt(bf):


### PR DESCRIPTION
Fixes https://github.com/sync-for-science/tracking/issues/95

I tried to find an alternate source of ICD9 codes, hopefully something that already had the dots in them. Apparently no one is offering that. This just splices the dot in at position 3 and adds that (as well as the un-dotted code) to the BF.