### PR TITLE
Fix no codings match.

### DIFF
--- a/features/steps/argonaut.py
+++ b/features/steps/argonaut.py
@@ -16,7 +16,10 @@ ERROR_FIELD_NOT_PRESENT = '''
 {field} is not set.
 {json}
 '''
-ERROR_INVALID_BINDING = '{code} is not found in {system}.'
+ERROR_INVALID_BINDING = '''
+{code} is not found in {system}.
+{json}
+'''
 ERROR_REFERENCE_MATCH = '{reference} is not a {resource_type}.'
 ERROR_REQUIRED = '{name} not found.'
 ERROR_WRONG_FIXED = 'None of {values} match {value}.'
@@ -39,6 +42,13 @@ def get_resources(resource, filter_type):
                 if entry['resource']['resourceType'] == filter_type]
     else:
         return [resource]
+
+
+def in_value_set(coding, value_set_url):
+    try:
+        return systems.validate_code(coding.get('code'), value_set_url)
+    except systems.SystemNotRecognized:
+        return False
 
 
 @then(u'there exists one or more {name} in {field_name}')
@@ -141,7 +151,8 @@ def step_impl(context, field_name, value_set_url_one, value_set_url_two):
                                           field_name=field_name,
                                           json=json.dumps(found, indent=2))
             found = [coding.get('code') for coding in found.get('coding')
-                     if coding.get('system') in (value_set_url_one, value_set_url_two)]
+                     if in_value_set(coding, value_set_url_one)
+                     or in_value_set(coding, value_set_url_two)]
 
         assert found, \
             utils.bad_response_assert(context.response,
@@ -159,7 +170,8 @@ def step_impl(context, field_name, value_set_url_one, value_set_url_two):
             assert valid, utils.bad_response_assert(context.response,
                                                     ERROR_INVALID_BINDING,
                                                     code=code,
-                                                    system=system_names)
+                                                    system=system_names,
+                                                    json=json.dumps(res, indent=2))
 
 
 @then(u'{field_name} is bound to {value_set_url}')
@@ -179,7 +191,7 @@ def step_impl(context, field_name, value_set_url):
                                           field_name=field_name,
                                           json=json.dumps(found, indent=2))
             found = [coding.get('code') for coding in found.get('coding')
-                     if coding.get('system') == value_set_url]
+                     if in_value_set(coding, value_set_url)]
 
         assert found, \
             utils.bad_response_assert(context.response,
@@ -196,7 +208,8 @@ def step_impl(context, field_name, value_set_url):
             assert valid, utils.bad_response_assert(context.response,
                                                     ERROR_INVALID_BINDING,
                                                     code=code,
-                                                    system=value_set_url)
+                                                    system=value_set_url,
+                                                    json=json.dumps(res, indent=2))
 
 
 @then(u'there exists a fixed {field_name}={value}')

--- a/features/steps/argonaut.py
+++ b/features/steps/argonaut.py
@@ -151,8 +151,8 @@ def step_impl(context, field_name, value_set_url_one, value_set_url_two):
                                           field_name=field_name,
                                           json=json.dumps(found, indent=2))
             found = [coding.get('code') for coding in found.get('coding')
-                     if in_value_set(coding, value_set_url_one)
-                     or in_value_set(coding, value_set_url_two)]
+                     if in_value_set(coding, value_set_url_one) or
+                     in_value_set(coding, value_set_url_two)]
 
         assert found, \
             utils.bad_response_assert(context.response,


### PR DESCRIPTION
- Fix bug introduced in https://github.com/sync-for-science/test-suite/commit/9c48c62fe086cdf84f8c9f0986809e2c8c2b735d
- Improve debugging output.

This fixes https://github.com/sync-for-science/tracking/issues/107 and improves debugging output.

[An example where I forced a failure by hardcoding the code to 1234567890.](http://tests.dev.syncfor.science:9003/?report_id=71184a4a-c6b6-421e-bce4-95066178d96a#{"vendor":"Epic","tags":["vital-signs"],"override":""})