### PR TITLE
172 - Add tests for checking URLs in conformance statement

### DIFF
--- a/features/10-sync-for-science.feature
+++ b/features/10-sync-for-science.feature
@@ -56,3 +56,9 @@ Feature: Implements all the S4S requirements
     Scenario: Server implements Patient documents
         Given I have a valid conformance statement
         And this server supports Patient documents
+
+    Scenario: Conformance statement specifies authorize and token endpoints
+        Given I have a valid conformance statement
+        And OAuth is enabled
+        Then the conformance statement provides a authorize endpoint
+        And the conformance statement provides a token endpoint

--- a/features/10-sync-for-science.feature
+++ b/features/10-sync-for-science.feature
@@ -57,8 +57,13 @@ Feature: Implements all the S4S requirements
         Given I have a valid conformance statement
         And this server supports Patient documents
 
-    Scenario: Conformance statement specifies authorize and token endpoints
+    Scenario: Conformance statement specifies authorize and token OAuth endpoints
         Given I have a valid conformance statement
         And OAuth is enabled
-        Then the conformance statement provides a valid authorize endpoint
-        And the conformance statement provides a valid token endpoint
+        Then the conformance statement provides a authorize endpoint
+        And the conformance statement provides a token endpoint
+
+    Scenario: Conformance statement OAuth endpoints are valid
+        Given I have a valid conformance statement
+        And OAuth is enabled
+        Then all endpoints in the conformance statement are valid

--- a/features/10-sync-for-science.feature
+++ b/features/10-sync-for-science.feature
@@ -60,5 +60,5 @@ Feature: Implements all the S4S requirements
     Scenario: Conformance statement specifies authorize and token endpoints
         Given I have a valid conformance statement
         And OAuth is enabled
-        Then the conformance statement provides a authorize endpoint
-        And the conformance statement provides a token endpoint
+        Then the conformance statement provides a valid authorize endpoint
+        And the conformance statement provides a valid token endpoint

--- a/features/steps/s4s.py
+++ b/features/steps/s4s.py
@@ -6,6 +6,8 @@ from behave import given, then, when, register_type
 import parse
 import requests
 
+from testsuite import fhir
+
 from features.steps import utils
 
 ERROR_MISSING_CONFORMANCE_STATEMENT = '''
@@ -18,6 +20,9 @@ ERROR_VALIDATION_ISSUES = '''
 Resource failed to validate.
 
 {issues}
+'''
+ERROR_CONFORMANCE_MISSING_ENDPOINT = '''
+OAuth2 endpoint "{0}" not found in the conformance statement.
 '''
 MU_CCDS_MAPPINGS = {
     'Server metadata': 'metadata',
@@ -159,3 +164,9 @@ def step_impl(context, version_name):
         utils.bad_response_assert(context.response,
                                   ERROR_VALIDATION_ISSUES,
                                   issues=json.dumps(issues, indent=4))
+
+@then('the conformance statement provides a {endpoint_type} endpoint')
+def step_impl(context, endpoint_type):
+    urls = fhir.get_oauth_uris(context.conformance)
+    assert endpoint_type in urls, \
+        ERROR_CONFORMANCE_MISSING_ENDPOINT.format(endpoint_type)

--- a/features/steps/s4s.py
+++ b/features/steps/s4s.py
@@ -165,6 +165,7 @@ def step_impl(context, version_name):
                                   ERROR_VALIDATION_ISSUES,
                                   issues=json.dumps(issues, indent=4))
 
+
 @then('the conformance statement provides a {endpoint_type} endpoint')
 def step_impl(context, endpoint_type):
     urls = fhir.get_oauth_uris(context.conformance)

--- a/features/steps/s4s.py
+++ b/features/steps/s4s.py
@@ -170,17 +170,25 @@ def step_impl(context, version_name):
                                   issues=json.dumps(issues, indent=4))
 
 
-@then('the conformance statement provides a valid {endpoint_type} endpoint')
+@then('the conformance statement provides a {endpoint_type} endpoint')
 def step_impl(context, endpoint_type):
     urls = fhir.get_oauth_uris(context.conformance)
     endpoint_url = urls.get(endpoint_type)
     assert endpoint_url is not None, \
         ERROR_CONFORMANCE_MISSING_ENDPOINT.format(endpoint_type)
 
-    try:
-        parsed_url = urlparse(endpoint_url)
-        if not parsed_url.scheme:
-            raise ValueError
-    except ValueError:
-        assert False, ERROR_CONFORMANCE_MALFORMED_ENDPOINT.format(endpoint_type,
-                                                                  endpoint_url)
+
+@then('all endpoints in the conformance statement are valid')
+def step_impl(context):
+    urls = fhir.get_oauth_uris(context.conformance)
+
+    for endpoint_type, endpoint_url in urls.items():
+        try:
+            parsed_url = urlparse(endpoint_url)
+            if not parsed_url.scheme:
+                raise ValueError
+        except ValueError:
+            assert False, ERROR_CONFORMANCE_MALFORMED_ENDPOINT.format(
+                endpoint_type,
+                endpoint_url
+            )


### PR DESCRIPTION
sync-for-science/tracking#172

Only `authorize` and `token` are required (http://docs.smarthealthit.org/authorization/conformance-statement/). However, if one of these are missing then the entire test suite fails to run anyway, at least for `SMART_EHR_STU3`...

Should we also validate the URLs themselves?