### PR TITLE
177 - Update smoking status to use code instead of social history, but allow for fallback

### DIFF
--- a/features/00-smoking.feature
+++ b/features/00-smoking.feature
@@ -1,6 +1,10 @@
 @use.with_use_case=ehr @smoking-status
 Feature: Smoking status
 
+    Scenario: Correct URI
+        Given I have a Smoking status response
+        Then the correct URI was used
+
     Scenario: Correct resourceType
         Given I have a Smoking status response
         Then the resourceType field will be Bundle

--- a/features/steps/s4s.py
+++ b/features/steps/s4s.py
@@ -31,7 +31,7 @@ OAuth2 "{0}" endpoint "{1}" is not a valid URI.
 MU_CCDS_MAPPINGS = {
     'Server metadata': 'metadata',
     'Patient demographics': 'Patient/{patientId}',
-    'Smoking status': 'Observation?category=social-history&patient={patientId}',
+    'Smoking status': 'Observation?code=http://loinc.org%7C72166-2&patient={patientId}',
     'Problems': 'Condition?patient={patientId}',
     'Lab results': 'Observation?category=laboratory&patient={patientId}',
     'Medication orders': 'MedicationOrder?patient={patientId}',

--- a/features/steps/s4s.py
+++ b/features/steps/s4s.py
@@ -140,9 +140,6 @@ def step_impl(context, mu_ccds_query):  # pylint: disable=W0613
 
     context.execute_steps('then the response code should be 200')
 
-    assert not context.response.history, \
-        'Request was redirected'
-
 
 @then('the correct URI was used')
 def step_impl(context):

--- a/features/steps/s4s.py
+++ b/features/steps/s4s.py
@@ -134,9 +134,7 @@ def step_impl(context, mu_ccds_query):
 
 
 @given('I have a {mu_ccds_query:MU_CCDS} response')
-def step_impl(context, mu_ccds_query):
-    query = mu_ccds_query.format(patientId=context.vendor_config['versioned_api'].get('patient'))
-
+def step_impl(context, mu_ccds_query):  # pylint: disable=W0613
     assert context.response is not None, \
         'Missing response.'
 

--- a/features/steps/s4s.py
+++ b/features/steps/s4s.py
@@ -140,6 +140,9 @@ def step_impl(context, mu_ccds_query):  # pylint: disable=W0613
 
     context.execute_steps('then the response code should be 200')
 
+    assert not context.response.history, \
+        'Request was redirected'
+
 
 @then('the correct URI was used')
 def step_impl(context):


### PR DESCRIPTION
sync-for-science/tracking#177

I played around with a few approaches and this is the clearest one. Adds a new scenario to the smoking status feature which shows a failure when the fallback URI (social history) is used, but the rest of the feature can continue.